### PR TITLE
Use currentTarget instead of srcElement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 0.1.2 - 2016-09-06
+
+* [Bug fix] Change the JS to use currentTarget instead of srcElement to work in anything but chrome!
+
+
 ### 0.1.1 - 2016-09-06
 
 * Expose confirm method to set the pin to nil

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pinfirmable (0.1.1)
+    pinfirmable (0.1.2)
       devise (~> 4.0)
       rails (~> 5.0.0, >= 5.0.0.1)
 

--- a/app/assets/javascripts/pinfirmable.js
+++ b/app/assets/javascripts/pinfirmable.js
@@ -23,7 +23,7 @@ var pinfirmable = {
   },
 
   handleDigitPress: function(event) {
-    var elem = event.srcElement;
+    var elem = event.currentTarget;
     elem.value = event.key;
 
     var nextElem = this.nextElement(elem);
@@ -37,7 +37,7 @@ var pinfirmable = {
   },
 
   handleBackspacePress: function(event) {
-    var elem = event.srcElement;
+    var elem = event.currentTarget;
     if(elem.value.length > 0) {
       elem.value = "";
     } else {

--- a/lib/pinfirmable/version.rb
+++ b/lib/pinfirmable/version.rb
@@ -1,3 +1,3 @@
 module Pinfirmable
-  VERSION = "0.1.1".freeze
+  VERSION = "0.1.2".freeze
 end


### PR DESCRIPTION
srcElement isn't on the standards track, as a result auto tabbing wasn't working in Firefox.