### PR TITLE
✨ Way to get out of pinfirmable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pinfirmable (0.1.3)
+    pinfirmable (0.1.4)
       devise (~> 4.0)
       rails (~> 5.0.0, >= 5.0.0.1)
 

--- a/app/controllers/devise/pinfirmable_controller.rb
+++ b/app/controllers/devise/pinfirmable_controller.rb
@@ -1,5 +1,7 @@
 module Devise
   class PinfirmableController < DeviseController
+    include ActionView::Helpers::UrlHelper
+
     def new
       @locked_out = locked_out?
     end
@@ -25,7 +27,9 @@ module Devise
     end
 
     def resend_email
-      flash[:notice] = "We have just resent your code"
+      flash[:notice] = t("pinfirmable.resend_email.notice_html",
+                         email: pinfirmable_user.email,
+                         not_correct_link: link_to(t("pinfirmable.resend_email.incorrect_email"), destroy_session_path(resource_name), method: :delete))
       PinfirmableMailer.pin_email(pinfirmable_user).deliver
       redirect_to user_confirmemail_path
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,3 +10,7 @@ en:
       We do this to make sure that we are creating your account with the correct email address and to stop any account being created in error.
     no_email: "Not received an email?"
     rate_limit: "You're trying too many times, please try again in a minute."
+  pinfirmable:
+    resend_email:
+      notice_html: "We have just resent your code to %{email}. %{not_correct_link}"
+      incorrect_email: "Not the right email?"

--- a/lib/pinfirmable/version.rb
+++ b/lib/pinfirmable/version.rb
@@ -1,3 +1,3 @@
 module Pinfirmable
-  VERSION = "0.1.3".freeze
+  VERSION = "0.1.4".freeze
 end

--- a/spec/controllers/pinfirmable_controller/resend_email_spec.rb
+++ b/spec/controllers/pinfirmable_controller/resend_email_spec.rb
@@ -15,7 +15,9 @@ RSpec.describe Devise::PinfirmableController do
 
     it "sets the flash" do
       post :resend_email
-      expect(flash[:notice]).to eq("We have just resent your code")
+      expect(flash[:notice]).to eq(I18n.t("pinfirmable.resend_email.notice_html",
+                                          email: "test@example.com",
+                                          not_correct_link: "<a rel=\"nofollow\" data-method=\"delete\" href=\"/users/sign_out\">Not the right email?</a>"))
     end
   end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -31,4 +31,5 @@ ActiveRecord::Schema.define(version: 20160901131628) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
 end


### PR DESCRIPTION
Users may enter wrong email so show them the email we are sending to and
give them an option to get out of session.